### PR TITLE
Remove table warnings when loading grib file

### DIFF
--- a/app/convert.py
+++ b/app/convert.py
@@ -42,6 +42,8 @@ def convert(tmpdirname: str, subfolder: str = None):
 
             # https://apps.ecmwf.int/codes/grib/format/grib1/centre/0/
             message['centre'] = 'kwbc'
+            message['subCentre'] = 0
+            message['table2Version'] = 1
 
             # TODO: include information on rotated lat/lon for DP2?
             # https://apps.ecmwf.int/codes/grib/format/grib1/ctable/6/


### PR DESCRIPTION
When loading the grib file in R, many warnings are printed. The same can be reproduced by running
`gdalinfo harmonie_xy_dp3_2025-03-24_08_wind_isobaricInhPa925_14hours.grb`

which gives many lines like this:
```
Warning 1: GRIB: Don't understand the parameter table, since center 7-255 used
parameter table version 253 instead of 3 (international exchange).
Using default for now (which might lead to erroneous interpretation), but please email arthur.taylor@noaa.gov
about adding this table to his 'degrib1.c' and 'grib1tab.c' files.
```

See https://codes.ecmwf.int/grib/format/grib1/sections/1/ for the specifications.

Indeed, the centre 'kwbc' (in https://github.com/SensingClues/harmonie-grib/blob/bugfix/table_warnings/app/convert.py#L44) is 7, 8 or 9 (so 7-255): https://codes.ecmwf.int/grib/format/mars/centre/

Parameter table version is not set explicitly, but in the original repository, this change was made 3 weeks ago:
https://github.com/MennoTammens/harmonie-grib/commit/09afcf82a6b9b9243960fc449c5c6a23ecc75443

The resulting grib files in https://www.euroszeilen.utwente.nl/weer/grib/ do not show the same warning when I do `gdalinfo`, so I think these additional lines might solve the issue.

I can only test it on the analytical server since I do not have the KNMI API key. We can test it by running the container, adjusting these 3 lines and calling `gdalinfo` on the resulting grib file, or looking for the warnings in the shiny logs for the crane radar.